### PR TITLE
Allow doc comments in `bitflags!` and `bitfields!`

### DIFF
--- a/common/src/regs/macros.rs
+++ b/common/src/regs/macros.rs
@@ -1,25 +1,32 @@
 #[macro_export]
 macro_rules! bitmasks {
     {
+        $(#[$outer:meta])*
         $valtype:ty, $reg_desc:ident, [
-            $( $field:ident $a:tt ),+
+            $( $(#[$inner:meta])* $field:ident $a:tt ),+
         ]
     } => {
-        $( bitmasks!($valtype, $reg_desc, $field, $a, []); )*
+        $(#[$outer])*
+        $( bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $a, []); )*
     };
 
+
     {
+        $(#[$outer:meta])*
         $valtype:ty, $reg_desc:ident, [
-            $( $field:ident $a:tt $b:tt ),+
+            $( $(#[$inner:meta])* $field:ident $a:tt $b:tt ),+
         ]
     } => {
-        $( bitmasks!($valtype, $reg_desc, $field, $a, $b); )*
+        $(#[$outer])*
+        $( bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $a, $b); )*
     };
 
+
     {
-        $valtype:ty, $reg_desc:ident, $field:ident,
+
+        $valtype:ty, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     ($shift:expr, Mask($mask:expr)),
-                    [$( $valname:ident = $value:expr ),*]
+                    [$( $(#[$inner:meta])* $valname:ident = $value:expr ),*]
     } => {
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
@@ -27,6 +34,7 @@ macro_rules! bitmasks {
 
         #[allow(non_snake_case)]
         #[allow(unused)]
+        $(#[$outer])*
         pub mod $field {
             #[allow(unused_imports)]
             use $crate::regs::FieldValue;
@@ -35,13 +43,16 @@ macro_rules! bitmasks {
             $(
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
+            $(#[$inner])*
             pub const $valname: FieldValue<$valtype, $reg_desc> = FieldValue::<$valtype, $reg_desc>::new($mask, $shift, $value);
             )*
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
+            $(#[$outer])*
             pub enum Value {
                 $(
+                    $(#[$inner])*
                     $valname = $value,
                 )*
             }
@@ -49,15 +60,17 @@ macro_rules! bitmasks {
     };
 
     {
-        $valtype:ty, $reg_desc:ident, $field:ident, $bit:expr,
-        [$( $valname:ident = $value:expr),* ]
+         $valtype:ty, $reg_desc:ident, $(#[$outer:meta])* $field:ident, $bit:expr,
+        [$( $(#[$inner:meta])* $valname:ident = $value:expr),* ]
     } => {
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
+        $(#[$outer])*
         pub const $field: Field<$valtype, $reg_desc> = Field::<$valtype, $reg_desc>::new(1, $bit);
 
         #[allow(non_snake_case)]
         #[allow(unused)]
+        $(#[$outer])*
         pub mod $field {
             #[allow(unused_imports)]
             use $crate::regs::FieldValue;
@@ -66,6 +79,7 @@ macro_rules! bitmasks {
             $(
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
+            $(#[$inner])*
             pub const $valname: FieldValue<$valtype, $reg_desc> = FieldValue::<$valtype, $reg_desc>::new(1, $bit, $value);
             )*
 
@@ -79,8 +93,10 @@ macro_rules! bitmasks {
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
+            $(#[$outer])*
             pub enum Value {
                 $(
+                    $(#[$inner])*
                     $valname = $value,
                 )*
             }
@@ -91,16 +107,19 @@ macro_rules! bitmasks {
 #[macro_export]
 macro_rules! bitfields {
     {
-        $valtype:ty, $( $reg:ident $reg_desc:ident $fields:tt ),*
+        $valtype:ty, $( $(#[$inner:meta])* $reg:ident $reg_desc:ident $fields:tt ),*
     } => {
         $(
+            $(#[$inner])*
             pub struct $reg_desc;
             impl $crate::regs::RegisterLongName for $reg_desc {}
 
             #[allow(non_snake_case)]
+            $(#[$inner])*
             pub mod $reg {
                 use $crate::regs::Field;
                 use super::$reg_desc;
+
 
                 bitmasks!( $valtype, $reg_desc, $fields );
             }


### PR DESCRIPTION
This will help in documenting the gpio parts in the chip crates (`chips/mk66/src/gpio.rs`), and perhaps in other places as well.