### PR TITLE
Add libtock-c submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tock"]
 	path = tock
 	url = https://github.com/helena-project/tock.git
+[submodule "libtock-c"]
+	path = libtock-c
+	url = https://github.com/tock/libtock-c.git

--- a/apps/MakeVariables.mk
+++ b/apps/MakeVariables.mk
@@ -1,2 +1,2 @@
 APPS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-TOCK_USERLAND_BASE_DIR := $(APPS_DIR)../tock/userland
+TOCK_USERLAND_BASE_DIR := $(APPS_DIR)../libtock-c


### PR DESCRIPTION
This pull request adds the tock/libtock-c repo as a submodule, which is necessary to compile the example apps.